### PR TITLE
initial checkin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# docker volumes
+volumes/
+
 # Distribution / packaging
 .Python
 env/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+
+## Getting Started with Docker Compose 
+
+Read confluent doc  https://docs.confluent.io/current/cp-docker-images/docs/quickstart.html#getting-started-with-docker-compose
+Note: we are not using docker-machine. start from `2 Clone the CP Docker Images Github Repository.`
+
+### setup
+  Just run `setup.sh` this will setup a docker composition of zookeeper, kafka, kafka-rest, kafka-connect (with a customized directory watcher)
+  ![image](https://user-images.githubusercontent.com/47808/31259202-d892eb4e-a9f9-11e7-8b6c-e9b34b5d398b.png)
+
+

--- a/bin/build-connectors
+++ b/bin/build-connectors
@@ -1,0 +1,35 @@
+#!/bin/bash
+# create an image to build kafka connectors
+echo "## checking for connector build image..."
+[ ! -z $(docker images -q kafka-connector-builder:latest) ] || docker build -t kafka-connector-builder -f kafka-connector-builder.dockerfile .
+if [ -z $(docker images -q kafka-connector-builder:latest) ]; then
+  echo "builder does not exist FAIL"; exit 1
+fi
+echo "builder exists OK"
+
+docker inspect  --format="{{.State.Running}}" builder > /dev/null
+if [ $? -ne 0 ]; then
+  echo "## Starting builder..."
+  docker run --name builder -v $(pwd)/volumes/jars:/jars -d -t kafka-connector-builder bash
+fi
+docker inspect  --format="{{.State.Running}}" builder > /dev/null
+if [ $? -ne 0 ]; then
+  echo "builder not running FAIL"; exit 1
+fi
+echo "builder running OK"
+
+echo "## building connectors ..."
+rm -f volumes/jars/connect-directory-source-1.0-all.jar
+# the build step already built the connector we want to use
+# so copy that target to our volume
+docker exec builder bash -c "git pull origin s3; gradle shadowJar; cp build/libs/connect-directory-source-1.0-all.jar  /jars"
+#
+# # check all ok
+
+echo "## checking for successful build of our connector DirectorySourceConnector..."
+if [ -e "volumes/jars/connect-directory-source-1.0-all.jar" ]; then
+  echo "connect-directory-source-1.0-all.jar OK"
+else
+  echo "connect-directory-source-1.0-all.jar FAIL"
+  exit 1
+fi

--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,1 @@
+docker-compose stop ; docker-compose rm -f

--- a/bin/directory-source
+++ b/bin/directory-source
@@ -1,0 +1,47 @@
+#!/bin/bash
+echo "## checking DirectorySourceConnector worker..."
+curl --silent  localhost:28082/connector-plugins | grep DirectorySourceConnector > /dev/null
+if [ $? -eq 0 ]; then
+  echo "DirectorySourceConnector found OK"
+else
+  echo "DirectorySourceConnector not found FAIL"
+  exit 1
+fi
+
+
+echo "## checking DirectorySourceConnector topic..."
+# create it if not exists
+docker run \
+  --net=host \
+  --rm \
+  confluentinc/cp-kafka:3.3.0 \
+  kafka-topics --create --topic directory-topic --partitions 1 --replication-factor 1 --if-not-exists --zookeeper localhost:32181 > /dev/null
+
+docker run    --net=host    --rm    confluentinc/cp-kafka:3.3.0    kafka-topics --describe --zookeeper localhost:32181 | grep directory-topic > /dev/null
+if [ $? -eq 0 ]; then
+  echo "DirectorySourceConnector topic found OK"
+else
+  echo "DirectorySourceConnector topic  not found, FAIL"
+  exit 1
+fi
+
+echo "## checking directory-source worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/directory-source/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "directory-source found OK"
+else
+  echo "### directory-source not found creating it..."
+  echo "### will publish directory entries of /files on topic 'directory-topic'..."
+  curl -s -X POST \
+  -H "Content-Type: application/json" \
+  --data '{ "name": "directory-source", "config": {"tasks.max": 1, "connector.class": "org.apache.kafka.connect.directory.DirectorySourceConnector", "topic": "directory-topic", "schema.name": "directory",  "check.dir.ms": 1000, "directories.paths": "/files"} }' \
+  http://localhost:28082/connectors > /dev/null
+  sleep 10
+  curl --fail --silent  localhost:28082/connectors/directory-source/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "directory-source found OK"
+  else 
+    echo "directory-source could not be created FAIL"
+    exit 1
+  fi
+fi

--- a/bin/elastic-sink
+++ b/bin/elastic-sink
@@ -1,0 +1,52 @@
+#!/bin/bash
+echo "## checking elasticsearch-sink worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/elasticsearch-sink/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "elasticsearch-sink found OK"
+else
+  echo "### elasticsearch-sink not found creating it..."
+  echo "### will read directory entries of from topic 'directory-topic,s3-topic,file-topic' and write to elastic indices ..."
+  curl --silent -X POST -H "Content-Type: application/json" --data \
+  '{
+  "name":"elasticsearch-sink",
+  "config":{
+    "connector.class":"io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+    "type.name":"directory",
+    "tasks.max":"1",
+    "topics":"directory-topic,s3-topic,file-topic",
+    "key.ignore":true,
+    "schema.ignore":true,
+    "connection.url":"http://localhost:9200",
+ "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+ "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+ "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+ "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable":false,
+    "internal.key.converter.schemas.enable": false,
+    "internal.value.converter.schemas.enable": false,
+    "schemas.enable": false
+  }
+  }' \
+  http://localhost:28082/connectors > /dev/null
+  printf '.'
+  sleep 10
+  curl --fail --silent  localhost:28082/connectors/elasticsearch-sink/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "elasticsearch-sink found OK"
+  else
+    echo "elasticsearch-sink could not be created FAIL"
+    exit 1
+  fi
+fi
+
+echo "## wait for elastic index to create ..."
+until $(curl --output /dev/null --silent  --fail localhost:9200/directory-topic); do
+    printf '.'
+    sleep 5
+done
+echo "elastic index created OK"
+
+echo '## list directory elements from elasticsearch...'
+curl --silent  localhost:9200/directory-topic/_search | jq .
+curl --silent  localhost:9200/s3-topic/_search | jq .
+curl --silent  localhost:9200/file-topic/_search | jq .

--- a/bin/file-source
+++ b/bin/file-source
@@ -1,0 +1,52 @@
+#!/bin/bash
+echo "## checking file-source worker in kafka worker config..."
+
+echo "## checking FileStreamSourceConnector topic..."
+# create it if not exists
+docker run \
+  --net=host \
+  --rm \
+  confluentinc/cp-kafka:3.3.0 \
+  kafka-topics --create --topic file-topic --partitions 1 --replication-factor 1 --if-not-exists --zookeeper localhost:32181 > /dev/null
+
+# place some data in the files
+ls -la > volumes/files/test.txt
+
+curl --silent --fail  localhost:28082/connectors/file-source/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "file-source found OK"
+else
+  echo "### file-source not found creating it..."
+  echo "### will read directory entries of from topic 'file-topic' and write to elastic index 'file-topic' ..."
+  curl --silent -X POST -H "Content-Type: application/json" --data \
+  '{
+  "name":"file-source",
+  "config":{
+    "connector.class":"org.apache.kafka.connect.file.FileStreamSourceConnector",
+    "file":"/files/test.txt",
+    "tasks.max":"1",
+    "topic":"file-topic"
+  }
+  }' \
+  http://localhost:28082/connectors > /dev/null
+  printf '.'
+  sleep 10
+  curl --fail --silent  localhost:28082/connectors/file-source/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "file-source found OK"
+  else
+    echo "file-source could not be created FAIL"
+    exit 1
+  fi
+fi
+
+echo "## wait for elastic index to create ..."
+until $(curl --output /dev/null --silent  --fail localhost:9200/file-topic); do
+    printf '.'
+    sleep 5
+done
+echo "elastic index created OK"
+
+echo '## list directory elements from elasticsearch...'
+curl --silent  localhost:9200/file-topic/_search | jq .
+curl --silent  localhost:9200/s3-topic/_search | jq .

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,33 @@
+#!/bin/bash
+# start VMs
+# you should have docker & docker compose already setup
+docker-compose --version >> /dev/null
+if [ $? -ne 0 ]; then
+  echo "you should have docker & docker compose already setup FAIL"; exit 1
+fi
+
+
+# initialize our host volumes
+mkdir -p volumes/jars
+mkdir -p volumes/files
+mkdir -p volumes/elastic/backups
+
+echo "## checking for successful build of our connectors ..."
+if [ -e "volumes/jars/connect-directory-source-1.0-all.jar" ]; then
+  echo "connect-directory-source-1.0-all.jar OK"
+else
+  ( bin/build-connectors )
+fi
+
+echo "## create docker compose images..."
+docker-compose create 
+echo "## start docker compose images..."
+docker-compose start
+
+echo "## wait for kafka connect to start up..."
+until $(curl --output /dev/null --silent  --fail localhost:28082/connectors); do
+    printf '.'
+    sleep 5
+done
+echo "kafka connect up OK"
+

--- a/bin/jdbc-sink
+++ b/bin/jdbc-sink
@@ -1,0 +1,39 @@
+#!/bin/bash
+echo "## checking jdbc-sink worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/jdbc-sink/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "jdbc-sink found OK"
+else
+  echo "### jdbc-sink not found creating it..."
+  echo "### will read directory entries of from topic 'directory-topic' and write to jdbc tables..."
+  curl --silent -X POST -H "Content-Type: application/json" --data \
+  '{
+  "name":"jdbc-sink",
+  "config":{
+    "connector.class":"io.confluent.connect.jdbc.JdbcSinkConnector",
+    "tasks.max":"1",
+    "topics":"directory-topic",
+    "connection.url":"jdbc:sqlite:/files/test.db",
+    "auto.create": true,
+    "auto.evolve": true,
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter"
+  }
+  }' \
+  http://localhost:28082/connectors > /dev/null
+  printf '.'
+  sleep 10
+  curl --fail --silent  localhost:28082/connectors/jdbc-sink/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "jdbc-sink found OK"
+  else
+    echo "jdbc-sink could not be created FAIL"
+    exit 1
+  fi
+fi
+
+echo '## list directory elements from jdbc...'
+sleep 10
+echo .tables | sqlite3  volumes/files/test.db

--- a/bin/s3-source
+++ b/bin/s3-source
@@ -32,7 +32,7 @@ if [ $? -eq 0 ]; then
   echo "s3-source found OK"
 else
   echo "### s3-source not found creating it..."
-  echo "### will publish directory entries of /tmp on topic 's3-topic'..."
+  echo "### will publish directory entries of s3 container on topic 's3-topic'..."
 curl -s -X POST \
 -H "Content-Type: application/json" \
 --data '{ "name": "s3-source", 
@@ -51,11 +51,17 @@ curl -s -X POST \
  "value.converter": "org.apache.kafka.connect.storage.StringConverter",
  "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
  "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+ "value.converter.schemas.enable":false,
  "internal.key.converter.schemas.enable": false,
- "internal.value.converter.schemas.enable": false
+ "internal.value.converter.schemas.enable": false,
+ "schemas.enable": false
    } }' \
 http://localhost:28082/connectors > /dev/null
-  sleep 5
+  sleep 10
+ # "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+ # "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+ # "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+ # "value.converter": "org.apache.kafka.connect.storage.StringConverter",
   curl --fail --silent  localhost:28082/connectors/s3-source/status  > /dev/null
   if [ $? -eq 0 ]; then
     echo "s3-source found OK"

--- a/directory_consumer.py
+++ b/directory_consumer.py
@@ -1,0 +1,15 @@
+from kafka import KafkaConsumer
+import json
+
+# To consume latest messages and auto-commit offsets
+consumer = KafkaConsumer('directory_topic',
+                         group_id='my-group',
+                         bootstrap_servers=['localhost:29092'],
+                         consumer_timeout_ms=5000, 
+			 auto_offset_reset='earliest', enable_auto_commit=False) 
+for message in consumer:
+    # message value and key are raw bytes -- decode if necessary!
+    # e.g., for unicode: `message.value.decode('utf-8')`
+    print ("%s:%d:%d: payload=%s"      % (message.topic, message.partition,
+                                          message.offset, 
+                                          json.loads(message.value)['payload']))

--- a/directory_consumer.py
+++ b/directory_consumer.py
@@ -12,4 +12,4 @@ for message in consumer:
     # e.g., for unicode: `message.value.decode('utf-8')`
     print ("%s:%d:%d: payload=%s"      % (message.topic, message.partition,
                                           message.offset, 
-                                          json.loads(message.value)['payload']))
+                                          json.loads(message.value)))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,96 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    network_mode: host
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    network_mode: host
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: localhost:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  schema_registry:
+    image: confluentinc/cp-schema-registry:3.3.0
+    network_mode: host
+    depends_on:
+      - zookeeper
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: localhost
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'localhost:32181'
+      SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
+
+
+  kafka-rest:
+    image: confluentinc/cp-kafka-rest:3.3.0
+    network_mode: host
+    depends_on:
+      - zookeeper
+      - kafka
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: localhost:32181 
+      KAFKA_REST_LISTENERS: http://localhost:8082 
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://localhost:8081 
+      KAFKA_REST_HOST_NAME: localhost 
+
+  kafka-connect:
+    image: confluentinc/cp-kafka-connect:3.3.0
+    network_mode: host
+    depends_on:
+      - zookeeper
+      - kafka
+    volumes:
+      # Specify an absolute path mapping
+      - "./volumes/jars:/etc/kafka-connect/jars"
+    environment:
+      CONNECT_PRODUCER_INTERCEPTOR_CLASSES: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor   
+      CONNECT_CONSUMER_INTERCEPTOR_CLASSES: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor   
+      CONNECT_BOOTSTRAP_SERVERS: localhost:29092   
+      CONNECT_REST_PORT: 28082   
+      CONNECT_GROUP_ID: "quickstart"   
+      CONNECT_CONFIG_STORAGE_TOPIC: "quickstart-config"   
+      CONNECT_OFFSET_STORAGE_TOPIC: "quickstart-offsets"   
+      CONNECT_STATUS_STORAGE_TOPIC: "quickstart-status"   
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1   
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1   
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1   
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
+      CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
+      CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
+      CONNECT_REST_ADVERTISED_HOST_NAME: "localhost"   
+      CONNECT_LOG4J_ROOT_LOGLEVEL: INFO 
+      CONNECT_LOG4J_LOGGERS: "org.reflections: ERROR"   
+
+
+
+  # Elastic Search
+  # note: on docker for mac, you may need to adjust the docker-machines' config
+  # if you get this error ....
+  # elastic    | ERROR: bootstrap checks failed
+  # elastic    | max virtual memory areas vm.max_map_count [65530] likely too low, increase to at least [262144]
+  # ... see this
+  # https://github.com/elastic/elasticsearch-docker/blob/master/README.md#osx-with-docker-toolbox
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+    volumes:
+      - "./volumes/elastic/backups:/backups/"
+    ports:
+      - "9200:9200"
+    network_mode: host
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+      - path.repo=/backups
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,9 +70,10 @@ services:
       CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
       CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"   
       CONNECT_REST_ADVERTISED_HOST_NAME: "localhost"   
-      CONNECT_LOG4J_ROOT_LOGLEVEL: INFO 
+      CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: "org.reflections: ERROR"   
-
+      AWS_ACCESS_KEY_ID: 724596f1fe184f02b8c682fa2734a4e6
+      AWS_SECRET_ACCESS_KEY: ae40a4e76d1d4aeea74b85142b18a8fb
 
 
   # Elastic Search

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,16 +19,16 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
-  schema_registry:
-    image: confluentinc/cp-schema-registry:3.3.0
-    network_mode: host
-    depends_on:
-      - zookeeper
-      - kafka
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: localhost
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'localhost:32181'
-      SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
+#  schema_registry:
+#    image: confluentinc/cp-schema-registry:3.3.0
+#    network_mode: host
+#    depends_on:
+#      - zookeeper
+#      - kafka
+#    environment:
+#      SCHEMA_REGISTRY_HOST_NAME: localhost
+#      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'localhost:32181'
+#      SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
 
 
   kafka-rest:
@@ -40,8 +40,9 @@ services:
     environment:
       KAFKA_REST_ZOOKEEPER_CONNECT: localhost:32181 
       KAFKA_REST_LISTENERS: http://localhost:8082 
-      KAFKA_REST_SCHEMA_REGISTRY_URL: http://localhost:8081 
+#      KAFKA_REST_SCHEMA_REGISTRY_URL: http://localhost:8081 
       KAFKA_REST_HOST_NAME: localhost 
+      KAFKA_REST_BOOTSTRAP_SERVERS: localhost:29092
 
   kafka-connect:
     image: confluentinc/cp-kafka-connect:3.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     volumes:
       # Specify an absolute path mapping
       - "./volumes/jars:/etc/kafka-connect/jars"
+      - "./volumes/files:/files"
     environment:
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor   
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor   
@@ -96,3 +97,11 @@ services:
       - xpack.security.enabled=false
       - path.repo=/backups
 
+  ui:
+    image: landoop/kafka-topics-ui
+    ports:
+      - "8000:8000"
+    network_mode: host
+    environment:
+      - KAFKA_REST_PROXY_URL=http://localhost:8082
+      - PROXY=true

--- a/kafka-connector-builder.dockerfile
+++ b/kafka-connector-builder.dockerfile
@@ -3,11 +3,42 @@ FROM confluentinc/cp-kafka-connect
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y maven
+RUN apt-get install -y vim
 VOLUME ["/jars"]
+
+ENV GRADLE_HOME /opt/gradle
+ENV GRADLE_VERSION 4.2.1
+
+ARG GRADLE_DOWNLOAD_SHA256=b551cc04f2ca51c78dd14edb060621f0e5439bdfafa6fd167032a09ac708fbc0
+RUN set -o errexit -o nounset \
+  && echo "Downloading Gradle" \
+  && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+  \
+  && echo "Checking download hash" \
+  && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+  \
+  && echo "Installing Gradle" \
+  && unzip gradle.zip \
+  && rm gradle.zip \
+  && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+  && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \
+  \
+  && echo "Adding gradle user and group" \
+  && groupadd --system --gid 1000 gradle \
+  && useradd --system --gid gradle --uid 1000 --shell /bin/bash --create-home gradle \
+  && mkdir /home/gradle/.gradle \
+  && chown --recursive gradle:gradle /home/gradle \
+  \
+  && echo "Symlinking root Gradle cache to gradle Gradle cache" \
+  && ln -s /home/gradle/.gradle /root/.gradle
+
 # build one connector to prime maven's repo with commonly used jars
 RUN git clone https://github.com/ohsu-comp-bio/kafka-connect-directory-source.git
 WORKDIR kafka-connect-directory-source
-RUN mvn clean
-RUN mvn package
+RUN git checkout -b s3
+RUN git pull origin s3
+#RUN mvn clean
+#RUN mvn package -Dmaven.test.skip=true
 # see https://docs.confluent.io/current/connect/userguide.html#running-workers
+RUN gradle shadowJar
 

--- a/kafka-connector-builder.dockerfile
+++ b/kafka-connector-builder.dockerfile
@@ -1,0 +1,13 @@
+FROM confluentinc/cp-kafka-connect
+# see https://docs.confluent.io/current/connect/managing.html#using-community-connectors
+RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y maven
+VOLUME ["/jars"]
+# build one connector to prime maven's repo with commonly used jars
+RUN git clone https://github.com/ohsu-comp-bio/kafka-connect-directory-source.git
+WORKDIR kafka-connect-directory-source
+RUN mvn clean
+RUN mvn package
+# see https://docs.confluent.io/current/connect/userguide.html#running-workers
+

--- a/python-kafka-consumer.dockerfile
+++ b/python-kafka-consumer.dockerfile
@@ -1,0 +1,3 @@
+FROM python:2.7
+# install kafka dependency
+RUN pip install kafka-python

--- a/s3.sh
+++ b/s3.sh
@@ -1,0 +1,91 @@
+echo "## checking S3SourceConnector worker..."
+curl --silent  localhost:28082/connector-plugins | grep org.apache.kafka.connect.directory.S3DirectorySourceConnector > /dev/null
+if [ $? -eq 0 ]; then
+  echo "S3DirectorySourceConnector found OK"
+else
+  echo "S3DirectorySourceConnector not found FAIL"
+  echo "build connector jar via $docker run --rm -v $(pwd)/volumes/jars:/jars -it kafka-connector-builder bash"
+  exit 1
+fi
+
+
+echo "## checking S3SourceConnector topic..."
+# create it if not exists
+docker run \
+  --net=host \
+  --rm \
+  confluentinc/cp-kafka:3.3.0 \
+  kafka-topics --create --topic s3-topic --partitions 1 --replication-factor 1 --if-not-exists --zookeeper localhost:32181 > /dev/null
+
+docker run    --net=host    --rm    confluentinc/cp-kafka:3.3.0    kafka-topics --describe --zookeeper localhost:32181 | grep s3-topic > /dev/null
+if [ $? -eq 0 ]; then
+  echo "S3DirectorySourceConnector topic found OK"
+else
+  echo "S3DirectorySourceConnector topic  not found, FAIL"
+  exit 1
+fi
+
+
+echo "## checking s3-source worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/s3-source/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "s3-source found OK"
+else
+  echo "### s3-source not found creating it..."
+  echo "### will publish directory entries of /tmp on topic 's3-topic'..."
+curl -s -X POST \
+-H "Content-Type: application/json" \
+--data '{ "name": "s3-source", 
+ "config": {"tasks.max": 1, 
+ "connector.class": "org.apache.kafka.connect.directory.S3DirectorySourceConnector", 
+ "topic": "s3-topic", 
+ "consumer.max.poll.records": 1000, 
+ "task.shutdown.graceful.timeout.ms":30000, 
+ "bucket": "etl-development", 
+ "interval_ms": "60000", 
+ "region_name": "us-west-2", 
+ "bucket_names": "etl-development", 
+ "schema_name": "s3",  
+ "service_endpoint": "http://10.96.11.20:8080", 
+ "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+ "value.converter": "org.apache.kafka.connect.storage.StringConverter",
+ "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter",
+ "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter",
+ "internal.key.converter.schemas.enable": false,
+ "internal.value.converter.schemas.enable": false
+   } }' \
+http://localhost:28082/connectors > /dev/null
+  sleep 5
+  curl --fail --silent  localhost:28082/connectors/s3-source/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "s3-source found OK"
+  else
+    echo "s3-source could not be created FAIL"
+    exit 1
+  fi
+fi
+
+exit 0 
+
+echo "## read from s3-source's topic"
+docker run \
+ --net=host \
+ --rm \
+ confluentinc/cp-kafka:3.3.0 \
+ kafka-console-consumer --bootstrap-server localhost:29092 --topic s3-topic --new-consumer --from-beginning --max-messages 4
+
+
+
+docker run \
+ --net=host \
+ --rm \
+ confluentinc/cp-kafka:3.3.0 \
+ kafka-console-consumer --bootstrap-server localhost:29092 --topic s3-topic --new-consumer --from-beginning --max-messages 4 \
+ --formatter kafka.tools.DefaultMessageFormatter \
+      --property print.key=true \
+      --property key.deserializer=org.apache.kafka.common.serialization.StringDeserializer \
+      --property value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+
+
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# you should have docker & docker compose already setup
+docker-compose --version >> /dev/null
+if [ $? -ne 0 ]; then
+  echo "you should have docker & docker compose already setup FAIL"; exit 1
+fi
+
+
+# initialize our host volumes
+mkdir -p volumes/jars
+mkdir -p volumes/elastic/backups
+
+# create an image to build kafka connectors
+echo "## checking for connector build image..."
+[ ! -z $(docker images -q kafka-connector-builder:latest) ] || docker build -t kafka-connector-builder -f kafka-connector-builder.dockerfile .
+if [ -z $(docker images -q kafka-connector-builder:latest) ]; then
+  echo $?
+  echo "builder does not exist FAIL"; exit 1
+fi
+
+echo "builder does exists OK"
+
+# the build step already built the connector we want to use
+# so copy that target to our volume
+docker run --rm -v $(pwd)/volumes/jars:/jars -it kafka-connector-builder cp target/connect-directory-source-1.0-jar-with-dependencies.jar /jars
+
+# check all ok
+
+echo "## checking for successful build of our connector DirectorySourceConnector..."
+if [ -e "volumes/jars/connect-directory-source-1.0-jar-with-dependencies.jar" ]; then
+  echo "connect-directory-source-1.0-jar-with-dependencies.jar OK"
+else
+  echo "connect-directory-source-1.0-jar-with-dependencies.jar FAIL"
+  exit 1
+fi
+
+echo "## create docker compose images..."
+docker-compose create 
+echo "## start docker compose images..."
+docker-compose start
+
+echo "## wait for kafka connect to start up..."
+until $(curl --output /dev/null --silent  --fail localhost:28082/connectors); do
+    printf '.'
+    sleep 5
+done
+echo "kafka connect up OK"
+
+
+echo "## checking DirectorySourceConnector worker..."
+curl --silent  localhost:28082/connector-plugins | grep DirectorySourceConnector > /dev/null
+if [ $? -eq 0 ]; then
+  echo "DirectorySourceConnector found OK"
+else
+  echo "DirectorySourceConnector not found FAIL"
+  exit 1
+fi
+
+
+echo "## checking DirectorySourceConnector topic..."
+# create it if not exists
+docker run \
+  --net=host \
+  --rm \
+  confluentinc/cp-kafka:3.3.0 \
+  kafka-topics --create --topic directory_topic --partitions 1 --replication-factor 1 --if-not-exists --zookeeper localhost:32181 > /dev/null
+
+docker run    --net=host    --rm    confluentinc/cp-kafka:3.3.0    kafka-topics --describe --zookeeper localhost:32181 | grep directory_topic > /dev/null
+if [ $? -eq 0 ]; then
+  echo "DirectorySourceConnector topic found OK"
+else
+  echo "DirectorySourceConnector topic  not found, FAIL"
+  exit 1
+fi
+
+echo "## checking directory-source worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/directory-source/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "directory-source found OK"
+else
+  echo "### directory-source not found creating it..."
+  echo "### will publish directory entries of /tmp on topic 'directory_topic'..."
+  curl -s -X POST \
+  -H "Content-Type: application/json" \
+  --data '{ "name": "directory-source", "config": {"tasks.max": 1, "connector.class": "org.apache.kafka.connect.directory.DirectorySourceConnector", "topic": "directory_topic", "schema.name": "directory",  "check.dir.ms": 1000, "directories.paths": "/tmp"} }' \
+  http://localhost:28082/connectors > /dev/null
+  sleep 5
+  curl --fail --silent  localhost:28082/connectors/directory-source/status  > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "directory-source found OK"
+  else 
+    echo "directory-source could not be created FAIL"
+    exit 1
+  fi
+fi
+
+echo "## read from directory-source's topic"
+docker run \
+ --net=host \
+ --rm \
+ confluentinc/cp-kafka:3.3.0 \
+ kafka-console-consumer --bootstrap-server localhost:29092 --topic directory_topic --new-consumer --from-beginning --max-messages 10
+
+
+echo "## checking elasticsearch-sink worker in kafka worker config..."
+curl --silent --fail  localhost:28082/connectors/elasticsearch-sink/status  > /dev/null
+if [ $? -eq 0 ]; then
+  echo "elasticsearch-sink found OK"
+else
+  echo "### elasticsearch-sink not found creating it..."
+  echo "### will read directory entries of from topic 'directory_topic' and write to elastic index 'directory_topic' ..."
+  curl -X POST -H "Content-Type: application/json" --data '{"name":"elasticsearch-sink","config":{"connector.class":"io.confluent.connect.elasticsearch.ElasticsearchSinkConnector","type.name":"directory","tasks.max":"1","topics":"directory_topic","key.ignore":"true","schema.ignore":"true","connection.url":"http://localhost:9200"}}'  http://localhost:28082/connectors
+  http://localhost:28082/connectors 
+  sleep 5
+  curl --fail --silent  localhost:28082/connectors/elasticsearch-sink/status  
+  if [ $? -eq 0 ]; then
+    echo "elasticsearch-sink found OK"
+  else
+    echo "elasticsearch-sink could not be created FAIL"
+    exit 1
+  fi
+fi
+
+echo '## list directory elements from elasticsearch...'
+curl --silent  localhost:9200/directory_topic/_search | jq -r  .hits.hits[]._source.path | uniq

--- a/setup.sh
+++ b/setup.sh
@@ -100,7 +100,7 @@ docker run \
  --net=host \
  --rm \
  confluentinc/cp-kafka:3.3.0 \
- kafka-console-consumer --bootstrap-server localhost:29092 --topic directory_topic --new-consumer --from-beginning --max-messages 10
+ kafka-console-consumer --bootstrap-server localhost:29092 --topic directory_topic --new-consumer --from-beginning --max-messages 4
 
 
 echo "## checking elasticsearch-sink worker in kafka worker config..."
@@ -110,10 +110,10 @@ if [ $? -eq 0 ]; then
 else
   echo "### elasticsearch-sink not found creating it..."
   echo "### will read directory entries of from topic 'directory_topic' and write to elastic index 'directory_topic' ..."
-  curl -X POST -H "Content-Type: application/json" --data '{"name":"elasticsearch-sink","config":{"connector.class":"io.confluent.connect.elasticsearch.ElasticsearchSinkConnector","type.name":"directory","tasks.max":"1","topics":"directory_topic","key.ignore":"true","schema.ignore":"true","connection.url":"http://localhost:9200"}}'  http://localhost:28082/connectors
-  http://localhost:28082/connectors 
+  curl --silent -X POST -H "Content-Type: application/json" --data '{"name":"elasticsearch-sink","config":{"connector.class":"io.confluent.connect.elasticsearch.ElasticsearchSinkConnector","type.name":"directory","tasks.max":"1","topics":"directory_topic","key.ignore":"true","schema.ignore":"true","connection.url":"http://localhost:9200"}}'  http://localhost:28082/connectors > /dev/null
+  printf '.'
   sleep 5
-  curl --fail --silent  localhost:28082/connectors/elasticsearch-sink/status  
+  curl --fail --silent  localhost:28082/connectors/elasticsearch-sink/status  > /dev/null
   if [ $? -eq 0 ]; then
     echo "elasticsearch-sink found OK"
   else
@@ -122,5 +122,73 @@ else
   fi
 fi
 
+echo "## wait for elastic index to create ..."
+until $(curl --output /dev/null --silent  --fail localhost:9200/directory_topic); do
+    printf '.'
+    sleep 5
+done
+echo "elastic index created OK"
+
 echo '## list directory elements from elasticsearch...'
-curl --silent  localhost:9200/directory_topic/_search | jq -r  .hits.hits[]._source.path | uniq
+curl --silent  localhost:9200/directory_topic/_search | jq -r  .hits.hits[]._source.path | sort |  uniq
+
+# create an image to build python consumer
+echo "## checking for python consumer image..."
+[ ! -z $(docker images -q python-kafka-consumer:latest) ] || docker build -t python-kafka-consumer -f python-kafka-consumer.dockerfile .
+if [ -z $(docker images -q python-kafka-consumer:latest) ]; then
+  echo $?
+  echo "python-kafka-consumer does not exist FAIL"; exit 1
+fi
+echo "python-kafka-consumer does exists OK"
+
+echo "## consuming directory_topic from python 'native' client..."
+docker run  --net=host --rm -it -v $(pwd)/directory_consumer.py:/directory_consumer.py python-kafka-consumer python /directory_consumer.py
+if [ $? -eq 0 ]; then
+  echo "directory_consumer.py OK"
+else
+  echo "directory_consumer.py FAIL"
+  exit 1
+fi
+
+echo "## consuming directory_topic meta data from REST interface ..."
+curl --silent localhost:8082/topics | grep directory_topic > /dev/null
+if [ $? -eq 0 ]; then
+  echo "REST metadata OK"
+else
+  echo "REST metadata FAIL"
+  exit 1
+fi
+
+
+# Create a consumer for JSON data, starting at the beginning of the topic's
+# log and subscribe to a topic. Then consume some data using the base URL in the first response.
+# Finally, close the consumer2 with a DELETE to make it leave the group and clean up
+# its resources.
+echo "## setting up REST consumer..."
+curl --silent  -X POST -H "Content-Type: application/vnd.kafka.v2+json" \
+      --data '{"name": "my_consumer_instance", "format": "json", "auto.offset.reset": "earliest"}' \
+      http://localhost:8082/consumers/my_json_consumer > /dev/null
+
+echo "## setting up REST consumer subscription to directory_topic..."
+curl --silent -X POST -H "Content-Type: application/vnd.kafka.v2+json" --data '{"topics":["directory_topic"]}' \
+ http://localhost:8082/consumers/my_json_consumer/instances/my_consumer_instance/subscription
+ # No content in response
+
+
+echo "## get REST consumer directory_topic messages..."
+while :
+do
+  curl --silent -X GET -H "Accept: application/vnd.kafka.json.v2+json" http://localhost:8082/consumers/my_json_consumer/instances/my_consumer_instance/records | grep directory_topic
+  if [ $? -eq 0 ]
+  then
+  	break            #Abandon the loop.
+  fi
+  printf '.'
+  sleep 5
+done
+
+
+echo "## delete REST consumer..."
+curl -X DELETE -H "Content-Type: application/vnd.kafka.v2+json" \
+       http://localhost:8082/consumers/my_json_consumer/instances/my_consumer_instance
+  # No content in response

--- a/setup.sh
+++ b/setup.sh
@@ -23,15 +23,15 @@ echo "builder does exists OK"
 
 # the build step already built the connector we want to use
 # so copy that target to our volume
-docker run --rm -v $(pwd)/volumes/jars:/jars -it kafka-connector-builder cp target/connect-directory-source-1.0-jar-with-dependencies.jar /jars
+# docker run --rm -v $(pwd)/volumes/jars:/jars -it kafka-connector-builder cp build/libs/connect-directory-source-1.0-all.jar  /jars
 
 # check all ok
 
 echo "## checking for successful build of our connector DirectorySourceConnector..."
-if [ -e "volumes/jars/connect-directory-source-1.0-jar-with-dependencies.jar" ]; then
-  echo "connect-directory-source-1.0-jar-with-dependencies.jar OK"
+if [ -e "volumes/jars/connect-directory-source-1.0-all.jar" ]; then
+  echo "connect-directory-source-1.0-all.jar OK"
 else
-  echo "connect-directory-source-1.0-jar-with-dependencies.jar FAIL"
+  echo "connect-directory-source-1.0-all.jar FAIL"
   exit 1
 fi
 


### PR DESCRIPTION
This PR contains several new features:
* a docker compose file to start:
   * zookeeper
   * kafka
   * kafka connect
   * schema registry
   * kafka rest
   * kafka connect plugins:
       *  [`directory-source`](https://github.com/ohsu-comp-bio/kafka-connect-directory-source) (custom)
       *  [`elasticsearch-sink`](https://docs.confluent.io/current/connect/connect-elasticsearch/docs/index.html) (bundled)
* a setup script that:
   * idempotently sets up resources
   * executes a simple setup that:
       * reads from `source /tmp` and writes to topic `directory_topic`
       * reads from topic `directory_topic` and writes to `elasticsearch index directory_topic`

 Just run `setup.sh` this will setup a docker composition of zookeeper, kafka, kafka-rest, kafka-connect (with a customized directory watcher)
  ![image](https://user-images.githubusercontent.com/47808/31259202-d892eb4e-a9f9-11e7-8b6c-e9b34b5d398b.png)

 


